### PR TITLE
update outdated performance claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ Redundancy Checksums (CRCs).
 
 * Calculation can be direct or via cached tables.
 
-* Speed is comparable to optimized C (checked against CRC32 in libz).
-
 * Only arrays of bytes are accepted as data (it's certainly possible
   to handle arbitrary sized sequences; previous versions did this, but
   it complicated the code for little practical gain so I removed it -
   please contact me if you want me to add it back).
+
+Although the performance of CRC.jl is good, even faster CRC-32 checksums are possible using the
+[heavily optimized C implementation](https://github.com/madler/zlib/blob/04f42ceca40f73e2978b50e93806c2a18c1281fc/crc32.c) in zlib
+via the [CRC32.jl package](https://github.com/JuliaIO/CRC32.jl), or using hardware-accelerated CRC-32c checksums in
+the [CRC32c standard library](https://docs.julialang.org/en/v1/stdlib/CRC32c/).
 
 ## Examples
 


### PR DESCRIPTION
I don't think it's accurate to say that it is comparable in performance to Mark Adler's [insanely optimized CRC-32](https://github.com/madler/zlib/blob/04f42ceca40f73e2978b50e93806c2a18c1281fc/crc32.c) implementation in zlib, available via the [CRC32.jl package](https://github.com/JuliaIO/CRC32.jl).  For example, here is a quick benchmark on my 2022 Apple M1 Max:
```jl
using CRC, CRC32, BenchmarkTools
const crc_32 = crc(CRC_32)
for k in (1,2,3,4,5)
    buf = rand(UInt8, 10^k)
    println("\nn = 10^$k:")
    @btime crc32($buf) # zlib, via CRC32.jl
    @btime crc_32($buf) # CRC.jl
end
```
which gives:
```
n = 10^1:
  7.166 ns (0 allocations: 0 bytes)
  211.786 ns (3 allocations: 96 bytes)

n = 10^2:
  81.608 ns (0 allocations: 0 bytes)
  255.802 ns (3 allocations: 96 bytes)

n = 10^3:
  238.767 ns (0 allocations: 0 bytes)
  765.487 ns (3 allocations: 96 bytes)

n = 10^4:
  1.712 μs (0 allocations: 0 bytes)
  5.938 μs (3 allocations: 96 bytes)

n = 10^5:
  16.666 μs (0 allocations: 0 bytes)
  57.833 μs (3 allocations: 96 bytes)
```
and the CRC32c standard lib (which has greater SIMD acceleration) is even faster (by another 4× for `10^5`).  See also #5.